### PR TITLE
Make extractColor a file method

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,6 +17,17 @@ Kirby::plugin('sylvainjule/colorextractor', [
         'de' => require_once __DIR__ . '/lib/languages/de.php',
         'fr' => require_once __DIR__ . '/lib/languages/fr.php',
     ),
+    'fileMethods' => [
+        'extractColor' => function() : Kirby\Cms\Field {
+            if($this->type() === 'image') {
+                $size          = option('sylvainjule.colorextractor.average') ? 1 : 300;
+                $fallbackColor = option('sylvainjule.colorextractor.fallBackColor');
+
+                SylvainJule\ColorExtractor::extractColor($this, $size, $fallbackColor);
+            }
+            return $this->color();
+        }
+    ],
     'api' => array(
     	'routes' => require_once __DIR__ . '/lib/routes.php',
     ),

--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -1,19 +1,10 @@
-<?php 
-
-function extractFile($file) {
-	if($file->type() == 'image') {
-    	$size          = option('sylvainjule.colorextractor.average') ? 1 : 300;
-    	$fallbackColor = option('sylvainjule.colorextractor.fallBackColor');
-
-    	SylvainJule\ColorExtractor::extractColor($file, $size, $fallbackColor);
-    }
-};
+<?php
 
 return array(
     'file.create:after'  => function ($file) {
-			extractFile($file);
-		},
+		$file->extractColor();
+	},
     'file.replace:after' => function ($newFile, $oldFile) {
-			extractFile($newFile);
-		},
+		$newFile->extractColor();
+	},
 );

--- a/lib/routes.php
+++ b/lib/routes.php
@@ -10,7 +10,7 @@ return array(
             $file          = $filesIndex->find($id);
 
         	try {
-        		$file->extractColors();
+        		$file->extractColor();
         		$response = array(
 		            'status' => 'success',
 		            'plugin' => 'colorextractor',

--- a/lib/routes.php
+++ b/lib/routes.php
@@ -8,11 +8,9 @@ return array(
             $id            = get('id');
             $filesIndex    = SylvainJule\ColorExtractor::getFilesIndex();
             $file          = $filesIndex->find($id);
-            $size          = option('sylvainjule.colorextractor.average') ? 1 : 300;
-        	$fallbackColor = option('sylvainjule.colorextractor.fallBackColor');
 
         	try {
-        		SylvainJule\ColorExtractor::extractColor($file, $size, $fallbackColor);
+        		$file->extractColors();
         		$response = array(
 		            'status' => 'success',
 		            'plugin' => 'colorextractor',


### PR DESCRIPTION
Previously, the color extraction process was started either from hooks or from the api route.
I propose to centralize this and create a file method to do the job:
```
$file->extractColor() : Kirby\Cms\Field
```