### PR TITLE
Switch to ColorThief for Color Extraction / (PHP 8.0  Kirby 3.7)

### DIFF
--- a/lib/colorextractor.php
+++ b/lib/colorextractor.php
@@ -16,8 +16,9 @@ class ColorExtractor {
             if(in_array($mode, ['dominant', 'both'])) {
                 $colors[] = static::processImage($image, 300, $fallbackColor);
             }
+            // Size below 10 seems to fail / timeout with ColorThief...
             if(in_array($mode, ['average', 'both'])) {
-                $colors[] = static::processImage($image, 1, $fallbackColor);
+                $colors[] = static::processImage($image, 10, $fallbackColor);
             }
 
 			$image->update(['color' => implode(',', $colors)]);

--- a/lib/colorextractor.php
+++ b/lib/colorextractor.php
@@ -2,9 +2,7 @@
 
 namespace SylvainJule;
 
-use League\ColorExtractor\Color;
-use League\ColorExtractor\ColorExtractor as Extractor;
-use League\ColorExtractor\Palette;
+use ColorThief\ColorThief;
 
 use Kirby\Cms\Files;
 use Kirby\Cms\File;
@@ -30,12 +28,11 @@ class ColorExtractor {
         $thumb     = $image->width() > $image->height() ? $image->resize(null, $size) : $image->resize($size);
         $thumb     = $thumb->save();
         $root      = $thumb->root();
-        $palette   = Palette::fromFilename($root, Color::fromHexToInt($fallbackColor));
-        $extractor = new Extractor($palette);
-        $colors    = $extractor->extract(1);
-        $hex       = Color::fromIntToHex($colors[0]);
 
-        return $hex;
+        // ColorThief::getColor($sourceImage[, $quality=10, $area=null, $outputFormat='array', $adapter = null])
+        $dominantColor = ColorThief::getColor($root, 10, null, 'hex', null);
+
+        return $dominantColor;
     }
 
     public static function getFilesIndex() {


### PR DESCRIPTION
#13 

Not sure if [League\ColorExtractor](https://github.com/thephpleague/color-extractor) will update to PHP 8 so I'm using [ColorThief\ColorThief](https://github.com/ksubileau/color-thief-php/) instead. This fork could likely use some polishing, but (with very little testing) seems to resolve things for me. 